### PR TITLE
accelerate hostname retrieval

### DIFF
--- a/var/public/cgi-bin/config.pl
+++ b/var/public/cgi-bin/config.pl
@@ -1,5 +1,7 @@
 #!/usr/bin/perl
 
+use Sys::Hostname;
+
 sub  FindAndReplace
 {
   local($line,%info)=@_;
@@ -1016,7 +1018,7 @@ sub GetOnlySystemVariables
    }
    close(NETWORKFILE);
 
-   $config{UDA_HOSTNAME}=`hostname`;
+   $config{UDA_HOSTNAME}=hostname;
 
    local($dnsfile)="/etc/resolv.conf";
    local($dnsnum)=1;


### PR DESCRIPTION
This function is called very often. System calls must not be made in that quantity for performance to be acceptable.

Fixes #12 