### PR TITLE
New Template flow multiple fixes

### DIFF
--- a/var/public/cgi-bin/templates.pl
+++ b/var/public/cgi-bin/templates.pl
@@ -130,7 +130,7 @@ sub NewTemplate
   print "<TR><TD>Operating System</TD><TD><SELECT NAME=OS ID=OS ONCHANGE='ReloadIndexedValues(\"OSFLAVOR\",flavorarray,this.options[this.selectedIndex].value);'></SELECT></TD></TR>\n";
   print "<TR><TD>Flavor</TD><TD><SELECT NAME=OSFLAVOR ID=OSFLAVOR></SELECT></TD></TR>\n";
   print "<TR><TD>Bind to MAC</TD><TD><INPUT TYPE=TEXT NAME=MAC></TD></TR>\n";
-  print "<TR><TD>Generate MAC Based PXE config</TD><TD><INPUT TYPE=TEXT NAME=GENERATEMAC></TD></TR>\n";
+  print "<TR><TD>Generate MAC Based PXE config</TD><TD><INPUT TYPE=CHECKBOX NAME=GENERATEMAC></TD></TR>\n";
   print "<TR><TD>Publish</TD><TD><INPUT TYPE=CHECKBOX NAME=PUBLISH CHECKED></TD></TR>\n";
   print "</TABLE>\n";
   print "</FORM>\n";


### PR DESCRIPTION
* first screen shows "Generate MAC based PXE config" as text field instead of checkbox
* second screen (after "next") does not show this field at all and also display previous "Bind to MAC" field description as "MAC"
* intermediate steps don't pass "Generate MAC based PXE config" choice at all, resulting it always being enabled
* also publish is always enabled at the end, even if you disable at the beginning

Also enhance error display

Fixes #15 